### PR TITLE
Modification to allow bypassing certificate check as Netatmo is

### DIFF
--- a/samples/netatmo/client/java-retrofit/pom.xml
+++ b/samples/netatmo/client/java-retrofit/pom.xml
@@ -16,6 +16,7 @@
   </prerequisites>
 
   <build>
+  <pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -105,6 +106,7 @@
         </configuration>
       </plugin>
     </plugins>
+    </pluginManagement>
   </build>
   <dependencies>
     <dependency>

--- a/samples/netatmo/client/java-retrofit/src/main/java/io/swagger/client/TrustingOkHttpClient.java
+++ b/samples/netatmo/client/java-retrofit/src/main/java/io/swagger/client/TrustingOkHttpClient.java
@@ -1,0 +1,52 @@
+package io.swagger.client;
+
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import com.squareup.okhttp.OkHttpClient;
+
+public class TrustingOkHttpClient extends OkHttpClient {
+	final TrustManager[] certs = new TrustManager[] { new X509TrustManager() {
+
+		@Override
+		public X509Certificate[] getAcceptedIssuers() {
+			return null;
+		}
+
+		@Override
+		public void checkServerTrusted(final X509Certificate[] chain, final String authType)
+				throws CertificateException {
+		}
+
+		@Override
+		public void checkClientTrusted(final X509Certificate[] chain, final String authType)
+				throws CertificateException {
+		}
+	}};
+	
+	public TrustingOkHttpClient() {
+		SSLContext ctx = null;
+		try {
+			ctx = SSLContext.getInstance("SSL");
+			ctx.init(null, certs, new SecureRandom());
+			final HostnameVerifier hostnameVerifier = new HostnameVerifier() {
+				@Override
+				public boolean verify(final String hostname, final SSLSession session) {
+					return true;
+				}
+			};
+			
+			this.setHostnameVerifier(hostnameVerifier);
+			this.setSslSocketFactory(ctx.getSocketFactory());
+		} catch (final java.security.GeneralSecurityException ex) {
+		}
+		
+	}
+}

--- a/samples/netatmo/client/java-retrofit/src/main/java/io/swagger/client/auth/OAuth.java
+++ b/samples/netatmo/client/java-retrofit/src/main/java/io/swagger/client/auth/OAuth.java
@@ -34,12 +34,8 @@ public class OAuth implements Interceptor {
         this.tokenRequestBuilder = requestBuilder;
     }
 
-    public OAuth(TokenRequestBuilder requestBuilder ) {
-        this(new OkHttpClient(), requestBuilder);
-    }
-
-    public OAuth(OAuthFlow flow, String authorizationUrl, String tokenUrl, String scopes) {
-        this(OAuthClientRequest.tokenLocation(tokenUrl).setScope(scopes));
+    public OAuth(OkHttpClient client, OAuthFlow flow, String authorizationUrl, String tokenUrl, String scopes) {
+        this(client, OAuthClientRequest.tokenLocation(tokenUrl).setScope(scopes));
         setFlow(flow);
         authenticationRequestBuilder = OAuthClientRequest.authorizationLocation(authorizationUrl);
     }

--- a/samples/netatmo/client/java-retrofit/src/test/java/io/swagger/netatmo/test/PartnerApiTest.java
+++ b/samples/netatmo/client/java-retrofit/src/test/java/io/swagger/netatmo/test/PartnerApiTest.java
@@ -27,7 +27,8 @@ public class PartnerApiTest {
         InputStream is = ClassLoader.getSystemResourceAsStream("unittest.properties");
         props.load(is);
         
-        ApiClient apiClient = new ApiClient("password_oauth",
+        ApiClient apiClient = new ApiClient(props.getProperty("io.swagger.client.bypasscert").equals("true"), 
+        		"password_oauth",
                 props.getProperty("io.swagger.client.client_id"),
                 props.getProperty("io.swagger.client.client_secret"),
                 props.getProperty("io.swagger.client.username"),

--- a/samples/netatmo/client/java-retrofit/src/test/java/io/swagger/netatmo/test/StationApiTest.java
+++ b/samples/netatmo/client/java-retrofit/src/test/java/io/swagger/netatmo/test/StationApiTest.java
@@ -17,6 +17,7 @@ import io.swagger.client.api.StationApi;
 import io.swagger.client.model.NADevice;
 import io.swagger.client.model.NADeviceListResponse;
 import io.swagger.client.model.NAUserResponse;
+import retrofit.RestAdapter.LogLevel;
 
 public class StationApiTest {
     
@@ -40,13 +41,13 @@ public class StationApiTest {
         rainId = props.getProperty("io.swagger.client.rain");
         windId = props.getProperty("io.swagger.client.wind");
         
-        ApiClient apiClient = new ApiClient("password_oauth",
+        ApiClient apiClient = new ApiClient(props.getProperty("io.swagger.client.bypasscert").equals("true"), "password_oauth",
                 props.getProperty("io.swagger.client.client_id"),
                 props.getProperty("io.swagger.client.client_secret"),
                 props.getProperty("io.swagger.client.username"),
                 props.getProperty("io.swagger.client.password"));
         apiClient.getTokenEndPoint().setScope("read_station");
-        //apiClient.getAdapterBuilder().setLogLevel(LogLevel.FULL);
+        apiClient.getAdapterBuilder().setLogLevel(LogLevel.FULL);
         
         api = apiClient.createService(StationApi.class);
     }

--- a/samples/netatmo/client/java-retrofit/src/test/java/io/swagger/netatmo/test/ThermostatApiTest.java
+++ b/samples/netatmo/client/java-retrofit/src/test/java/io/swagger/netatmo/test/ThermostatApiTest.java
@@ -47,7 +47,8 @@ public class ThermostatApiTest {
         relayId = props.getProperty("io.swagger.client.relay");
         thermostatId = props.getProperty("io.swagger.client.thermostat");
         
-        ApiClient apiClient = new ApiClient("password_oauth",
+        ApiClient apiClient = new ApiClient(props.getProperty("io.swagger.client.bypasscert").equals("true"), 
+        		"password_oauth",
                 props.getProperty("io.swagger.client.client_id"),
                 props.getProperty("io.swagger.client.client_secret"),
                 props.getProperty("io.swagger.client.username"),

--- a/samples/netatmo/client/java-retrofit/src/test/resources/unittest.properties
+++ b/samples/netatmo/client/java-retrofit/src/test/resources/unittest.properties
@@ -3,6 +3,7 @@ io.swagger.client.client_id = your_application_client_id
 io.swagger.client.client_secret = your_application_secret_id
 io.swagger.client.username = your_username
 io.swagger.client.password = your_password
+io.swagger.client.bypasscert = true
 
 #Uncomment and set to true if you want to test the partner api. You need to have a device associated
 #io.swagger.client.isPartner = false


### PR DESCRIPTION
providing a not trusted certificate.

The bypass of certificate control can be activated or not depending upon the property of io.swagger.client.bypasscert preserving original behaviour of the library.
